### PR TITLE
Renderへのデプロイエラー

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,6 +134,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.9-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.9-x86_64-linux)
+      racc (~> 1.4)
     parallel (1.22.1)
     parser (3.1.3.0)
       ast (~> 2.4.1)
@@ -253,6 +255,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap (= 1.12.0)


### PR DESCRIPTION
## 概要

RailsをRenderにデプロイした時下記のエラーが出たのでPlatformを追加
```
Your bundle only supports platforms ["x86_64-darwin-22"] but your local platform
is x86_64-linux. Add the current platform to the lockfile with
`bundle lock --add-platform x86_64-linux` and try again.
```

## やったこと

Gemfile.lockの更新
